### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,6 @@ export declare function render<T extends Node>(
 export class Hole {
   constructor(type: string, template: TemplateStringsArray, values: any[]);
   readonly type: string;
-  readonly template: readonly TemplateStringsArray;
+  readonly template: TemplateStringsArray;
   readonly values: readonly any[];
 }


### PR DESCRIPTION
It looks like this is maybe a typo.
It resulted in that I could not compile the project.

ERROR in [at-loader] ./node_modules/uhtml/index.d.ts:27:22
    TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.