### PR TITLE
Improve TS compatibility

### DIFF
--- a/async.d.ts
+++ b/async.d.ts
@@ -1,0 +1,8 @@
+import type { Renderable } from "./index";
+
+export declare function render<T extends Node>(
+  node: T,
+  renderer: (() => Renderable) | Renderable,
+): Promise<T>;
+
+export type { TemplateFunction, Tag, Renderable, html, svg, Hole } from "./index";

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export declare function render<T extends Node>(
  * Used for internal purposes, should be created using
  * the `html` or `svg` template tags.
  */
-export class Hole {
+export declare class Hole {
   constructor(type: string, template: TemplateStringsArray, values: any[]);
   readonly type: string;
   readonly template: TemplateStringsArray;

--- a/package.json
+++ b/package.json
@@ -48,22 +48,27 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./esm/index.js",
       "default": "./cjs/index.js"
     },
     "./async": {
+      "types": "./index.d.ts",
       "import": "./esm/async.js",
       "default": "./cjs/async.js"
     },
     "./init": {
+      "types": "./index.d.ts",
       "import": "./esm/init.js",
       "default": "./cjs/init.js"
     },
     "./json": {
+      "types": "./index.d.ts",
       "import": "./esm/json.js",
       "default": "./cjs/json.js"
     },
     "./jsx": {
+      "types": "./index.d.ts",
       "import": "./esm/x.js",
       "default": "./cjs/x.js"
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "default": "./cjs/index.js"
     },
     "./async": {
-      "types": "./index.d.ts",
+      "types": "./async.d.ts",
       "import": "./esm/async.js",
       "default": "./cjs/async.js"
     },


### PR DESCRIPTION
Fixes #84, adds types for the async module and makes sure that index.d.ts only exports type declarations.