### PR TITLE
uhtml/reactive 🦄

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ node.js
 !esm/node.js
 !esm/dom/node.js
 !test/dom/node.js
+reactive.js
+!esm/reactive.js
+!esm/render/reactive.js
+preactive.js
+!test/preactive.js

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@
 
 ### Exports
 
-  * `uhtml` as default `{ Hole, render, html, svg, attr }` with smart auto-keyed nodes - read [keyed or not ?](https://webreflection.github.io/uhtml/#keyed-or-not-) paragraph to know more
-  * `uhtml/keyed` with extras `{ Hole, render, html, svg, htmlFor, svgFor, attr }`, providing keyed utilities - read [keyed or not ?](https://webreflection.github.io/uhtml/#keyed-or-not-) paragraph to know more
-  * `uhtml/node` with *same default* exports but it's for *one-off* nodes creation only so that no cache or updates are available and it's just an easy way to hook *uhtml* into your existing project for DOM creation (not manipulation!)
-  * `uhtml/init` which returns a `document => uhtml/keyed` utility that can be bootstrapped with `uhtml/dom`, [LinkeDOM](https://github.com/WebReflection/linkedom), [JSDOM](https://github.com/jsdom/jsdom) for either *SSR* or *Workers* support
-  * `uhtml/dom` which returns a specialized *uhtml* compliant DOM environment that can be passed to the `uhtml/init` export to have 100% same-thing running on both client or Web Worker / Server. This entry exports `{ Document, DOMParser }` where the former can be used to create a new *document* while the latter one can parse well formed HTML or SVG content and return the document out of the box.
+  * **uhtml** as default `{ Hole, render, html, svg, attr }` with smart auto-keyed nodes - read [keyed or not ?](https://webreflection.github.io/uhtml/#keyed-or-not-) paragraph to know more
+  * **uhtml/keyed** with extras `{ Hole, render, html, svg, htmlFor, svgFor, attr }`, providing keyed utilities - read [keyed or not ?](https://webreflection.github.io/uhtml/#keyed-or-not-) paragraph to know more
+  * **uhtml/node** with *same default* exports but it's for *one-off* nodes creation only so that no cache or updates are available and it's just an easy way to hook *uhtml* into your existing project for DOM creation (not manipulation!)
+  * **uhtml/init** which returns a `document => uhtml/keyed` utility that can be bootstrapped with `uhtml/dom`, [LinkeDOM](https://github.com/WebReflection/linkedom), [JSDOM](https://github.com/jsdom/jsdom) for either *SSR* or *Workers* support
+  * **uhtml/dom** which returns a specialized *uhtml* compliant DOM environment that can be passed to the `uhtml/init` export to have 100% same-thing running on both client or Web Worker / Server. This entry exports `{ Document, DOMParser }` where the former can be used to create a new *document* while the latter one can parse well formed HTML or SVG content and return the document out of the box.
+  * **uhtml/reactive** which allows usage of symbols within the optionally *keyed* render function. The only difference with other exports, beside exporting a `reactive` field instead of `render`, so that `const render = reactive(effect)` creates a reactive render per each library, is that the `render(where, () => what)`, with a function as second argument is mandatory when the rendered stuff has signals in it, otherwise these can't side-effect properly.
+  * **uhtml/preactive** is an already bundled `uhtml/reactive` with `@preact/signals-core` in it, so that its `render` exported function, among all other *preact* related exports, is already working.
 
-**uhtml/init example**
+### uhtml/init example
 
 ```js
 import init from 'uhtml/init';
@@ -39,4 +41,18 @@ const {
   htmlFor, svgFor,
   attr
 } = init(document);
+```
+
+### uhtml/preactive example
+
+```js
+import { render, html, signal } from 'uhtml/preactive';
+
+const count = signal(0);
+
+render(document.body, () => html`
+  <button onclick=${() => { count.value++ }}>
+    Clicks: ${count.value}
+  </button>
+`);
 ```

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,7 +1,7 @@
 /*! (c) Andrea Giammarchi - MIT */
-
 import { Hole } from './rabbit.js';
 import { attr } from './handler.js';
+
 import render from './render/hole.js';
 
 /** @typedef {import("./literals.js").Value} Value */

--- a/esm/keyed.js
+++ b/esm/keyed.js
@@ -1,8 +1,10 @@
-import { cache } from './literals.js';
+/*! (c) Andrea Giammarchi - MIT */
 import { Hole, unroll } from './rabbit.js';
+import { attr } from './handler.js';
+import { cache } from './literals.js';
 import { empty, set } from './utils.js';
 import { html, svg } from './index.js';
-import { attr } from './handler.js';
+
 import render from './render/keyed.js';
 
 /** @typedef {import("./literals.js").Cache} Cache */

--- a/esm/node.js
+++ b/esm/node.js
@@ -1,9 +1,9 @@
 /*! (c) Andrea Giammarchi - MIT */
+import { attr } from './handler.js';
 
 import create from './creator.js';
 import parser from './parser.js';
 import render from './render/node.js';
-import { attr } from './handler.js';
 
 /** @typedef {import("./literals.js").DOMValue} DOMValue */
 /** @typedef {import("./literals.js").Target} Target */

--- a/esm/reactive.js
+++ b/esm/reactive.js
@@ -1,0 +1,6 @@
+/*! (c) Andrea Giammarchi - MIT */
+import { Hole, html, svg, htmlFor, svgFor, attr } from './keyed.js';
+
+import reactive from './render/reactive.js';
+
+export { Hole, reactive, html, svg, htmlFor, svgFor, attr };

--- a/esm/reactive/preact.js
+++ b/esm/reactive/preact.js
@@ -1,0 +1,8 @@
+import { effect } from '@preact/signals-core';
+export * from '@preact/signals-core';
+
+import { Hole, reactive, html, svg, htmlFor, svgFor, attr } from '../reactive.js';
+
+const render = reactive(effect);
+
+export { Hole, render, html, svg, htmlFor, svgFor, attr };

--- a/esm/render/hole.js
+++ b/esm/render/hole.js
@@ -1,5 +1,5 @@
-import { cache } from '../literals.js';
 import { unroll } from '../rabbit.js';
+import { cache } from '../literals.js';
 import { empty, set } from '../utils.js';
 
 /** @typedef {import("../rabbit.js").Hole} Hole */

--- a/esm/render/keyed.js
+++ b/esm/render/keyed.js
@@ -1,17 +1,17 @@
-import { cache } from '../literals.js';
 import { Hole, unroll } from '../rabbit.js';
+import { cache } from '../literals.js';
 import { empty, set } from '../utils.js';
 
 /** @type {WeakMap<Element | DocumentFragment, import("../literals.js").Cache>} */
 const known = new WeakMap;
 
 /**
- * Render with smart updates within a generic container.
- * @template T
- * @param {T} where the DOM node where to render content
- * @param {(() => Hole) | Hole} what the hole to render
- * @returns
- */
+  * Render with smart updates within a generic container.
+  * @template T
+  * @param {T} where the DOM node where to render content
+  * @param {(() => Hole) | Hole} what the hole to render
+  * @returns
+  */
 export default (where, what) => {
   const info = known.get(where) || set(known, where, cache(empty));
   const hole = typeof what === 'function' ? what() : what;

--- a/esm/render/reactive.js
+++ b/esm/render/reactive.js
@@ -1,0 +1,33 @@
+import { create, drop } from 'gc-hook';
+
+import render from './keyed.js';
+
+/** @type {WeakMap<Element | DocumentFragment, Function>} */
+const effects = new WeakMap;
+
+/**
+ * @param {Function} dispose
+ * @returns {void}
+ */
+const onGC = dispose => dispose();
+
+export default effect => {
+  /**
+   * Render with smart updates within a generic container.
+   * @template T
+   * @param {T} where the DOM node where to render content
+   * @param {() => Hole} what the hole to render
+   * @returns {T}
+   */
+  return (where, what) => {
+    let dispose = effects.get(where);
+    if (dispose) {
+      drop(dispose);
+      dispose();
+    }
+    const wr = new WeakRef(where);
+    dispose = effect(() => { render(wr.deref(), what) });
+    effects.set(where, dispose);
+    return create(dispose, onGC, { return: where });
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "4.2.2",
       "license": "MIT",
       "dependencies": {
+        "@preact/signals-core": "*",
         "@webreflection/uparser": "^0.3.3",
         "custom-function": "^1.0.6",
         "domconstants": "^1.1.6",
+        "gc-hook": "^0.3.0",
         "html-escaper": "^3.0.3",
         "htmlparser2": "^9.0.0",
         "udomdiff": "^1.1.0"
@@ -21,9 +23,11 @@
         "@rollup/plugin-terser": "^0.4.4",
         "ascjs": "^6.0.3",
         "c8": "^8.0.1",
-        "linkedom": "^0.16.5",
         "rollup": "^4.9.2",
         "typescript": "^5.3.3"
+      },
+      "optionalDependencies": {
+        "@preact/signals-core": "^1.5.1"
       }
     },
     "node_modules/@babel/parser": {
@@ -109,6 +113,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.5.1.tgz",
+      "integrity": "sha512-dE6f+WCX5ZUDwXzUIWNMhhglmuLpqJhuy3X3xHrhZYI0Hm2LyQwOu0l9mdPiWrVNsE+Q7txOnJPgtIqHCYoBVA==",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -429,12 +443,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -552,40 +560,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
     },
     "node_modules/custom-function": {
       "version": "1.0.6",
@@ -746,6 +720,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gc-hook": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/gc-hook/-/gc-hook-0.3.0.tgz",
+      "integrity": "sha512-Qkp0HM3z839Ns0LpXFJBXqClNW23wQo6JpUdJAjuf1/2jB+oUWSOMzeMv2yFq8Ur45z8IWw9hpRhkSjxSt5RWg=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -926,19 +905,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/linkedom": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.16.5.tgz",
-      "integrity": "sha512-FtcuLuxDtlKWWilm5Z0HgmrfMwO0tOfC6tu47fRXj2/KGEeDSh4ihiDwFKZSbJj6zh520r8XZjZ7v2Jb30HAQA==",
-      "dev": true,
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "cssom": "^0.5.0",
-        "html-escaper": "^3.0.3",
-        "htmlparser2": "^9.0.0",
-        "uhyphen": "^0.2.0"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -991,18 +957,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/once": {
@@ -1363,12 +1317,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/udomdiff/-/udomdiff-1.1.0.tgz",
       "integrity": "sha512-aqjTs5x/wsShZBkVagdafJkP8S3UMGhkHKszsu1cszjjZ7iOp86+Qb3QOFYh01oWjPMy5ZTuxD6hw5uTKxd+VA=="
-    },
-    "node_modules/uhyphen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
-      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "rollup:es": "rollup --config rollup/es.config.js",
     "rollup:init": "rollup --config rollup/init.config.js",
     "server": "npx static-handler .",
-    "size": "echo \"index $(cat index.js | brotli | wc -c)\";echo \"keyed $(cat keyed.js | brotli | wc -c)\";echo \"node  $(cat node.js | brotli | wc -c)\";",
+    "size": "echo \"index $(cat index.js | brotli | wc -c)\";echo \"keyed $(cat keyed.js | brotli | wc -c)\";echo \"reactive $(cat reactive.js | brotli | wc -c)\";echo \"preactive $(cat preactive.js | brotli | wc -c)\";echo \"node  $(cat node.js | brotli | wc -c)\";",
     "test": "c8 node test/coverage.js",
     "coverage": "mkdir -p ./coverage; c8 report --reporter=text-lcov > ./coverage/lcov.info",
     "ts": "tsc -p ."
@@ -59,6 +59,16 @@
       "import": "./esm/node.js",
       "default": "./cjs/node.js"
     },
+    "./reactive": {
+      "types": "./types/reactive.d.ts",
+      "import": "./esm/reactive.js",
+      "default": "./cjs/reactive.js"
+    },
+    "./preactive": {
+      "types": "./types/reactive/preact.d.ts",
+      "import": "./esm/reactive/preact.js",
+      "default": "./cjs/reactive/preact.js"
+    },
     "./package.json": "./package.json"
   },
   "unpkg": "./keyed.js",
@@ -66,6 +76,7 @@
     "@webreflection/uparser": "^0.3.3",
     "custom-function": "^1.0.6",
     "domconstants": "^1.1.6",
+    "gc-hook": "^0.3.0",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^9.0.0",
     "udomdiff": "^1.1.0"
@@ -77,5 +88,8 @@
   "bugs": {
     "url": "https://github.com/WebReflection/uhtml/issues"
   },
-  "homepage": "https://github.com/WebReflection/uhtml#readme"
+  "homepage": "https://github.com/WebReflection/uhtml#readme",
+  "optionalDependencies": {
+    "@preact/signals-core": "^1.5.1"
+  }
 }

--- a/rollup/es.config.js
+++ b/rollup/es.config.js
@@ -44,6 +44,22 @@ export default [
   },
   {
     plugins,
+    input: './esm/reactive.js',
+    output: {
+      esModule: true,
+      file: './reactive.js',
+    },
+  },
+  {
+    plugins,
+    input: './esm/reactive/preact.js',
+    output: {
+      esModule: true,
+      file: './preactive.js',
+    },
+  },
+  {
+    plugins,
     input: './esm/dom/index.js',
     output: {
       esModule: true,

--- a/test/preactive.html
+++ b/test/preactive.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>uhtml/preactive</title>
+  <script type="module">
+
+    import { render, html, signal } from '../preactive.js';
+
+    const count = signal(0);
+
+    render(document.body, () => html`
+      <button onclick=${() => { count.value++ }}>
+        Clicks: ${count.value}
+      </button>
+    `);
+  </script>
+</head>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
         "esm/init.js",
         "esm/keyed.js",
         "esm/node.js",
+        "esm/reactive.js",
+        "esm/reactive/preact.js",
         "esm/dom/index.js",
     ]
 }


### PR DESCRIPTION
This MR brings reactivity out of the box via signals based libraries.

You can bring your ogn signals based library or use the `uhtml/preactive` export which already bundles `@preact/signals-core` in it.

The main difference with the *reactive* export, or its *preactive* one, is that the *render* function needs the "what to render" second argument to be a callback, otherwise signals don't get a chance to side effect.