### PR TITLE
fix types for uhtml and uhtml/ssr; make it build

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -9,9 +9,9 @@ import render from './render/hole.js';
 const tag = svg => (template, ...values) => new Hole(svg, template, values);
 
 /** @type {(template: TemplateStringsArray, ...values:Value[]) => Hole} A tag to render HTML content. */
-const html = tag(false);
+export const html = tag(false);
 
 /** @type {(template: TemplateStringsArray, ...values:Value[]) => Hole} A tag to render SVG content. */
-const svg = tag(true);
+export const svg = tag(true);
 
-export { Hole, render, html, svg, attr };
+export { Hole, render, attr };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@rollup/plugin-terser": "^0.4.4",
     "ascjs": "^6.0.3",
     "c8": "^9.1.0",
-    "rollup": "^4.14.3"
+    "rollup": "^4.14.3",
+    "terser": "^5.30.3"
   },
   "module": "./esm/index.js",
   "type": "module",


### PR DESCRIPTION
As for the types, I think the JSDoc type definiton only works if `export const` is used :|

The `terser` package was missing for `pnpm build` to work.