### PR TITLE
Improving types for Deno and (other runtimes?)

### DIFF
--- a/build-utils/fix-types.js
+++ b/build-utils/fix-types.js
@@ -1,0 +1,16 @@
+import { copyFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import fg from "fast-glob"
+
+const dir = fileURLToPath(new URL("..", import.meta.url))
+
+const dts = await fg(resolve(dir, "types/**/*.d.ts"))
+
+// Create MTS and CTS files
+const dmts = dts.map(f => copyFileSync(f, f.replace(/\.d\.ts$/, ".d.mts")))
+const dcts = dts.map(f => copyFileSync(f, f.replace(/\.d\.ts$/, ".d.cts")))
+
+console.log(`Copied ${dmts.length} files from \`*.d.ts\` to \`*.d.mts\``)
+console.log(`Copied ${dcts.length} files from \`*.d.ts\` to \`*.d.cts\``)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "4.5.5",
       "license": "MIT",
       "dependencies": {
-        "@preact/signals-core": "1.6.0",
-        "@webreflection/signal": "2.1.2",
         "@webreflection/uparser": "^0.3.3",
         "custom-function": "^1.0.6",
         "domconstants": "^1.1.6",
@@ -28,6 +26,7 @@
         "@types/resolve": "^1.20.6",
         "ascjs": "^6.0.3",
         "c8": "^9.1.0",
+        "fast-glob": "^3.3.2",
         "rollup": "^4.14.3",
         "terser": "^5.30.3",
         "typescript": "^5.4.5"
@@ -187,6 +186,41 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@preact/signals-core": {
@@ -608,6 +642,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -901,11 +947,48 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -1002,6 +1085,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1089,6 +1184,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1098,11 +1202,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1238,6 +1363,28 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1349,6 +1496,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1393,6 +1560,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.14.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
@@ -1426,6 +1603,29 @@
         "@rollup/rollup-win32-ia32-msvc": "4.14.3",
         "@rollup/rollup-win32-x64-msvc": "4.14.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -1641,6 +1841,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/ts-expose-internals-conditionally": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage": "mkdir -p ./coverage; c8 report --reporter=text-lcov > ./coverage/lcov.info",
     "clean": "rm -rf coverage ./*.js cjs/**/*.js cjs/*.js types",
     "check:types": "npx attw --pack .",
-    "build:types": "rm -rf types && npx tsc -p tsconfig.json"
+    "build:types": "rm -rf types && npx tsc -p tsconfig.json && node build-utils/fix-types.js"
   },
   "keywords": [
     "micro",
@@ -36,6 +36,7 @@
     "@types/resolve": "^1.20.6",
     "ascjs": "^6.0.3",
     "c8": "^9.1.0",
+    "fast-glob": "^3.3.2",
     "rollup": "^4.14.3",
     "terser": "^5.30.3",
     "typescript": "^5.4.5"
@@ -44,53 +45,83 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
-      "default": "./cjs/index.js",
-      "types": "./types/index.d.ts"
+      "types": {
+        "default":"./types/index.d.mts",
+        "require":"./types-cjs/index.d.cts"
+      },
+      "default": "./esm/index.js",
+      "require": "./cjs/index.js"
     },
     "./dom": {
-      "import": "./esm/dom/index.js",
-      "default": "./cjs/dom/index.js",
-      "types": "./types/dom/index.d.ts"
+      "types": {
+        "default": "./types/dom/index.d.mts",
+        "require": "./types/dom/index.d.cts"
+      },
+      "default": "./esm/dom/index.js",
+      "require": "./cjs/dom/index.js"
     },
     "./init": {
-      "import": "./esm/init.js",
-      "default": "./cjs/init.js",
-      "types": "./types/keyed.d.ts"
+      "types": {
+        "default": "./types/keyed.d.mts",
+        "require": "./types/keyed.d.cts"
+      },
+      "default": "./esm/init.js",
+      "require": "./cjs/init.js"
     },
     "./keyed": {
-      "import": "./esm/keyed.js",
-      "default": "./cjs/keyed.js",
-      "types": "./types/keyed.d.ts"
+      "types": {
+        "default": "./types/keyed.d.mts",
+        "require": "./types/keyed.d.cts"
+      },
+      "default": "./esm/keyed.js",
+      "require": "./cjs/keyed.js"
     },
     "./node": {
-      "import": "./esm/node.js",
-      "default": "./cjs/node.js",
-      "types": "./types/node.d.ts"
+      "types": {
+        "default": "./types/node.d.mts",
+        "require": "./types/node.d.cts"
+      },
+      "default": "./esm/node.js",
+      "require": "./cjs/node.js"
     },
     "./reactive": {
-      "import": "./esm/reactive.js",
-      "default": "./cjs/reactive.js",
-      "types": "./types/reactive.d.ts"
+      "types": {
+        "default": "./types/reactive.d.mts",
+        "require": "./types/reactive.d.cts"
+      },
+      "default": "./esm/reactive.js",
+      "require": "./cjs/reactive.js"
     },
     "./preactive": {
-      "import": "./esm/reactive/preact.js",
-      "default": "./cjs/reactive/preact.js",
-      "types": "./types/reactive/preact.d.ts"
+      "types": {
+        "default":"./types/reactive/preact.d.mts",
+        "require": "./types/reactive/preact.d.cts"
+      },
+      "default": "./esm/reactive/preact.js",
+      "require": "./cjs/reactive/preact.js"
     },
     "./signal": {
-      "import": "./esm/reactive/signal.js",
-      "default": "./cjs/reactive/signal.js",
-      "types": "./types/reactive/signal.d.ts"
+      "types": {
+        "default":"./types/reactive/signal.d.mts",
+        "require":"./types-cjs/reactive/signal.d.cts"
+      },
+      "default": "./esm/reactive/signal.js",
+      "require": "./cjs/reactive/signal.js"
     },
     "./ssr": {
-      "import": "./esm/init-ssr.js",
-      "default": "./cjs/init-ssr.js",
-      "types": "./types/ssr.d.ts"
+      "types": {
+        "default":"./types/ssr.d.mts",
+        "require":"./types-cjs/ssr.d.cts"
+      },
+      "default": "./esm/init-ssr.js",
+      "require": "./cjs/init-ssr.js"
     },
     "./worker": {
-      "import": "./worker.js",
-      "types": "./types/ssr.d.ts"
+      "types": {
+        "default":"./types/ssr.d.mts",
+        "require":"./types-cjs/ssr.d.cts"
+      },
+      "default": "./worker.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Baased on Deno documentation https://docs.deno.com/runtime/manual/node/npm_specifiers#module-resolution node16 types resolution should probably happen without fallback. To allow this a .cts file should be present. 

Note: the order in the package exports count. types must be the first one.

<img width="846" alt="image" src="https://github.com/WebReflection/uhtml/assets/6770926/13dbbe64-8723-4de2-966a-91c0bac7fad1">

to run check of types do: 
```sh npm run build && npm run check:types```
