### PR TITLE
Make node.toString() output almost XML for SVG

### DIFF
--- a/esm/dom/attribute.js
+++ b/esm/dom/attribute.js
@@ -51,6 +51,6 @@ export default class Attribute extends Node {
 
   toString() {
     const { [name]: key, [value]: val } = this;
-    return val === '' ? key : `${key}="${escape(val)}"`;
+    return `${key}="${escape(val)}"`;
   }
 }


### PR DESCRIPTION
this patch makes the output a bit closer to XML, so that `node.toString()` can output SVG files.

i'm not sure how useful it is to output XML. I've used it to write SVG files by appending the XML header to `node.toString()`.

This relies on the fact that `VOID_ELEMENTS` does not contain the usual SVG elements. This is not robust at all.