### PR TITLE
Fix: explicit typescript type for asElement function

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,12 +15,13 @@ jobs:
         node-version: [20]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
     - run: npm ci
     - run: npm run build --if-present
     - run: npm run coverage --if-present

--- a/esm/dom/utils.js
+++ b/esm/dom/utils.js
@@ -6,7 +6,7 @@ import { empty } from '../utils.js';
 
 
 /**
- * @param {import("./element.js").default} element
+ * @param {{ [k in typeof nodeType]: number }}
  * @returns {boolean}
  */
 export const asElement = ({ [nodeType]: type }) => type === ELEMENT_NODE;

--- a/esm/dom/utils.js
+++ b/esm/dom/utils.js
@@ -6,7 +6,7 @@ import { empty } from '../utils.js';
 
 
 /**
- * @param {{ [k in typeof nodeType]: number }}
+ * @param {import("./element.js").default} element
  * @returns {boolean}
  */
 export const asElement = ({ [nodeType]: type }) => type === ELEMENT_NODE;

--- a/esm/dom/utils.js
+++ b/esm/dom/utils.js
@@ -4,6 +4,11 @@ import { childNodes, nodeType, parentNode } from './symbols.js';
 
 import { empty } from '../utils.js';
 
+
+/**
+ * @param {import("./element.js").default} element
+ * @returns {boolean}
+ */
 export const asElement = ({ [nodeType]: type }) => type === ELEMENT_NODE;
 
 export const changeParentNode = (node, parent) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "udomdiff": "^1.1.2"
       },
       "devDependencies": {
-        "@arethetypeswrong/cli": "~0.17.3",
+        "@arethetypeswrong/cli": "~0.17.4",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@types/estree": "^1.0.6",
@@ -27,7 +27,7 @@
         "ascjs": "^6.0.3",
         "c8": "^10.1.2",
         "fast-glob": "^3.3.2",
-        "publint": "~0.3.2",
+        "publint": "~0.3.12",
         "rollup": "^4.27.4",
         "terser": "^5.36.0",
         "typescript": "^5.7.2"
@@ -44,12 +44,13 @@
       "dev": true
     },
     "node_modules/@arethetypeswrong/cli": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.17.3.tgz",
-      "integrity": "sha512-wI9ZSTweunmzHboSyYtWRFpba9fM9mpX1g7EUoRr+86zHSd7NR7svb6EmJD2hv1V+SoisB2fERu6EQGGEfQ8oQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.17.4.tgz",
+      "integrity": "sha512-AeiKxtf67XD/NdOqXgBOE5TZWH3EOCt+0GkbUpekOzngc+Q/cRZ5azjWyMxISxxfp0EItgm5NoSld9p7BAA5xQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@arethetypeswrong/core": "0.17.3",
+        "@arethetypeswrong/core": "0.17.4",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -65,12 +66,14 @@
       }
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.17.3.tgz",
-      "integrity": "sha512-2TB7O5JmC7UX7QHRGGftxRVQjV4Ce6oOIDGIDDERyT9dQ8lK/tRGfFubzO80rWeXm/gSrA8jirlXSWSE1i5ynQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.17.4.tgz",
+      "integrity": "sha512-Izvir8iIoU+X4SKtDAa5kpb+9cpifclzsbA8x/AZY0k0gIfXYQ1fa1B6Epfe6vNA2YfDX8VtrZFgvnXB6aPEoQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
+        "@loaderkit/resolve": "^1.0.2",
         "cjs-module-lexer": "^1.2.3",
         "fflate": "^0.8.2",
         "lru-cache": "^10.4.3",
@@ -87,6 +90,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
       "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -152,6 +156,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@braidai/lang": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.1.tgz",
+      "integrity": "sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg==",
+      "dev": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -310,6 +320,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@loaderkit/resolve": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.4.tgz",
+      "integrity": "sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@braidai/lang": "^1.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -371,10 +391,11 @@
       }
     },
     "node_modules/@publint/pack": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.1.tgz",
-      "integrity": "sha512-TvCl79Y8v18ZhFGd5mjO1kYPovSBq3+4LVCi5Nfl1JI8fS8i8kXbgQFGwBJRXczim8GlW8c2LMBKTtExYXOy/A==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.2.tgz",
+      "integrity": "sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -936,10 +957,11 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
-      "dev": true
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
@@ -1293,7 +1315,8 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1833,10 +1856,11 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.8.tgz",
-      "integrity": "sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.2.0.tgz",
+      "integrity": "sha512-PutJepsOtsqVfUsxCzgTTpyXmiAgvKptIgY4th5eq5UXXFhj5PxfQ9hnGkypMeovpAvVshFRItoFHYO18TCOqA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "5.1.1",
@@ -1926,13 +1950,14 @@
       }
     },
     "node_modules/publint": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.2.tgz",
-      "integrity": "sha512-fPs7QUbUvwixxPYUUTn0Kqp0rbH5rbiAOZwQOXMkIj+4Nopby1AngodSQmzTkJWTJ5R4uVV8oYmgVIjj+tgv1w==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.12.tgz",
+      "integrity": "sha512-1w3MMtL9iotBjm1mmXtG3Nk06wnq9UhGNRpQ2j6n1Zq7YAD6gnxMMZMIxlRPAydVjVbjSm+n0lhwqsD1m4LD5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@publint/pack": "^0.1.1",
-        "package-manager-detector": "^0.2.8",
+        "@publint/pack": "^0.1.2",
+        "package-manager-detector": "^1.1.0",
         "picocolors": "^1.1.1",
         "sade": "^1.8.1"
       },
@@ -2449,6 +2474,7 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
       "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
-        "@preact/signals-core": "1.8.0",
-        "@webreflection/signal": "2.1.2",
         "@webreflection/uparser": "^0.4.0",
         "custom-function": "^2.0.0",
         "domconstants": "^1.1.6",
@@ -20,7 +18,7 @@
         "udomdiff": "^1.1.2"
       },
       "devDependencies": {
-        "@arethetypeswrong/cli": "~0.15.3",
+        "@arethetypeswrong/cli": "~0.17.3",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-terser": "^0.4.4",
         "@types/estree": "^1.0.6",
@@ -29,6 +27,7 @@
         "ascjs": "^6.0.3",
         "c8": "^10.1.2",
         "fast-glob": "^3.3.2",
+        "publint": "~0.3.2",
         "rollup": "^4.27.4",
         "terser": "^5.36.0",
         "typescript": "^5.7.2"
@@ -45,13 +44,12 @@
       "dev": true
     },
     "node_modules/@arethetypeswrong/cli": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.15.4.tgz",
-      "integrity": "sha512-YDbImAi1MGkouT7f2yAECpUMFhhA1J0EaXzIqoC5GGtK0xDgauLtcsZezm8tNq7d3wOFXH7OnY+IORYcG212rw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.17.3.tgz",
+      "integrity": "sha512-wI9ZSTweunmzHboSyYtWRFpba9fM9mpX1g7EUoRr+86zHSd7NR7svb6EmJD2hv1V+SoisB2fERu6EQGGEfQ8oQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@arethetypeswrong/core": "0.15.1",
+        "@arethetypeswrong/core": "0.17.3",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",
@@ -67,17 +65,17 @@
       }
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.17.3.tgz",
+      "integrity": "sha512-2TB7O5JmC7UX7QHRGGftxRVQjV4Ce6oOIDGIDDERyT9dQ8lK/tRGfFubzO80rWeXm/gSrA8jirlXSWSE1i5ynQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
+        "cjs-module-lexer": "^1.2.3",
         "fflate": "^0.8.2",
+        "lru-cache": "^10.4.3",
         "semver": "^7.5.4",
-        "ts-expose-internals-conditionally": "1.0.0-empty.0",
-        "typescript": "5.3.3",
+        "typescript": "5.6.1-rc",
         "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
@@ -85,11 +83,10 @@
       }
     },
     "node_modules/@arethetypeswrong/core/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.6.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+      "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -371,6 +368,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.1.tgz",
+      "integrity": "sha512-TvCl79Y8v18ZhFGd5mjO1kYPovSBq3+4LVCi5Nfl1JI8fS8i8kXbgQFGwBJRXczim8GlW8c2LMBKTtExYXOy/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -926,6 +935,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "dev": true
+    },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
@@ -1094,11 +1109,10 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1279,8 +1293,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1733,6 +1746,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1810,6 +1832,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.8.tgz",
+      "integrity": "sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==",
+      "dev": true
+    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -1878,6 +1906,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1889,6 +1923,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/publint": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.2.tgz",
+      "integrity": "sha512-fPs7QUbUvwixxPYUUTn0Kqp0rbH5rbiAOZwQOXMkIj+4Nopby1AngodSQmzTkJWTJ5R4uVV8oYmgVIjj+tgv1w==",
+      "dev": true,
+      "dependencies": {
+        "@publint/pack": "^0.1.1",
+        "package-manager-detector": "^0.2.8",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/queue-microtask": {
@@ -2021,6 +2076,18 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-buffer": {
@@ -2332,13 +2399,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/ts-expose-internals-conditionally": {
-      "version": "1.0.0-empty.0",
-      "resolved": "https://registry.npmjs.org/ts-expose-internals-conditionally/-/ts-expose-internals-conditionally-1.0.0-empty.0.tgz",
-      "integrity": "sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -2389,7 +2449,6 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
       "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "benchmark:w3c": "node test/benchmark/linkedom.js --w3c; node test/benchmark/linkedom-cached.js --w3c; node test/benchmark/dom.js --w3c",
     "benchmark:dom": "node test/benchmark/linkedom.js --dom; node test/benchmark/linkedom-cached.js --dom; node test/benchmark/dom.js --dom",
-    "build": "npm run rollup:es && node rollup/ssr.cjs && node rollup/init.cjs && npm run rollup:init && npm run rollup:ssr && rm -rf cjs/* && npm run cjs && npm run build:types && npm run test && npm run size",
+    "build": "npm run rollup:es && node rollup/ssr.cjs && node rollup/init.cjs && npm run rollup:init && npm run rollup:ssr && rm -rf cjs/* && npm run cjs && npm run build:types && npm run test && npm run size && npm run publint",
     "cjs": "ascjs --no-default esm cjs",
     "rollup:es": "rollup --config rollup/es.config.js",
     "rollup:init": "rollup --config rollup/init.config.js",
@@ -17,10 +17,9 @@
     "test": "c8 node test/coverage.js && node test/modern.mjs && node test/svg.mjs",
     "coverage": "mkdir -p ./coverage; c8 report --reporter=text-lcov > ./coverage/lcov.info",
     "clean": "rm -rf coverage ./*.js cjs/**/*.js cjs/*.js types",
-    "check:types": "npx attw --pack .",
+    "check:types": "npx attw $(npm pack) --profile esm-only",
     "build:types": "rm -rf types && npx tsc -p tsconfig.json && node rollup/ts.fix.js",
-    "are-the-types-wrong": "npx attw $(npm pack)",
-    "publint-package": "npx publint ."
+    "publint": "npx publint ."
   },
   "keywords": [
     "micro",
@@ -30,8 +29,8 @@
   "author": "Andrea Giammarchi",
   "license": "MIT",
   "devDependencies": {
-    "@arethetypeswrong/cli": "~0.17.3",
-    "publint": "~0.3.2",
+    "@arethetypeswrong/cli": "~0.17.4",
+    "publint": "~0.3.12",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/estree": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "coverage": "mkdir -p ./coverage; c8 report --reporter=text-lcov > ./coverage/lcov.info",
     "clean": "rm -rf coverage ./*.js cjs/**/*.js cjs/*.js types",
     "check:types": "npx attw --pack .",
-    "build:types": "rm -rf types && npx tsc -p tsconfig.json && node rollup/ts.fix.js"
+    "build:types": "rm -rf types && npx tsc -p tsconfig.json && node rollup/ts.fix.js",
+    "are-the-types-wrong": "npx attw $(npm pack)",
+    "publint-package": "npx publint ."
   },
   "keywords": [
     "micro",
@@ -28,7 +30,8 @@
   "author": "Andrea Giammarchi",
   "license": "MIT",
   "devDependencies": {
-    "@arethetypeswrong/cli": "~0.15.3",
+    "@arethetypeswrong/cli": "~0.17.3",
+    "publint": "~0.3.2",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/estree": "^1.0.6",
@@ -45,83 +48,83 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./esm/index.js",
       "types": {
         "require": "./types/index.d.cts",
         "default": "./types/index.d.mts"
       },
+      "import": "./esm/index.js",
       "default": "./cjs/index.js"
     },
     "./dom": {
-      "import": "./esm/dom/index.js",
       "types": {
         "require": "./types/dom/index.d.cts",
         "default": "./types/dom/index.d.mts"
       },
+      "import": "./esm/dom/index.js",
       "default": "./cjs/dom/index.js"
     },
     "./init": {
-      "import": "./esm/init.js",
       "types": {
         "require": "./types/init.d.cts",
         "default": "./types/init.d.mts"
       },
+      "import": "./esm/init.js",
       "default": "./cjs/init.js"
     },
     "./keyed": {
-      "import": "./esm/keyed.js",
       "types": {
         "require": "./types/keyed.d.cts",
         "default": "./types/keyed.d.mts"
       },
+      "import": "./esm/keyed.js",
       "default": "./cjs/keyed.js"
     },
     "./node": {
-      "import": "./esm/node.js",
       "types": {
         "require": "./types/node.d.cts",
         "default": "./types/node.d.mts"
       },
+      "import": "./esm/node.js",
       "default": "./cjs/node.js"
     },
     "./reactive": {
-      "import": "./esm/reactive.js",
       "types": {
         "require": "./types/reactive.d.cts",
         "default": "./types/reactive.d.mts"
       },
+      "import": "./esm/reactive.js",
       "default": "./cjs/reactive.js"
     },
     "./preactive": {
-      "import": "./esm/reactive/preact.js",
       "types": {
         "require": "./types/reactive/preact.d.cts",
         "default": "./types/reactive/preact.d.mts"
       },
+      "import": "./esm/reactive/preact.js",
       "default": "./cjs/reactive/preact.js"
     },
     "./signal": {
-      "import": "./esm/reactive/signal.js",
       "types": {
         "require": "./types/reactive/signal.d.cts",
         "default": "./types/reactive/signal.d.mts"
       },
+      "import": "./esm/reactive/signal.js",
       "default": "./cjs/reactive/signal.js"
     },
     "./ssr": {
-      "import": "./esm/init-ssr.js",
       "types": {
         "require": "./types/init-ssr.d.cts",
         "default": "./types/init-ssr.d.mts"
       },
+      "import": "./esm/init-ssr.js",
       "default": "./cjs/init-ssr.js"
     },
     "./worker": {
-      "import": "./worker.js",
       "types": {
         "require": "./types/init-ssr.d.cts",
         "default": "./types/init-ssr.d.mts"
-      }
+      },
+      "import": "./worker.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Typescript types generation fails with

`esm/dom/utils.js:8:14 - error TS4118: The type of this node cannot be serialized because its property '__@nodeType@27111' cannot be serialized.`

The jsdoc comment fix the issue 
I also added two commands to check the types and the package.json exports. 

Note: publint asserts that the types field in package.json must be the first one. this is why I moved it at the top of each exports section