### PR TITLE
Ensure components always return Holes

### DIFF
--- a/src/dom/rabbit.js
+++ b/src/dom/rabbit.js
@@ -218,7 +218,11 @@ export class Hole {
       if (type & COMPONENT) {
         if (type === COMPONENT) {
           if (DEBUG && typeof value !== 'function') throw errors.invalid_component(value);
-          const result = value(prev, global);
+          const wasDirect = getDirect();
+          if (wasDirect) setDirect(!wasDirect);
+          let result;
+          try { result = value(prev, global); }
+          finally { if (wasDirect) setDirect(wasDirect); }
           if (update) {
             if (DEBUG && !(result instanceof Hole)) throw errors.invalid_component(value);
             if (getHole(update, /** @type {Hole} */(result)) === result) entry[2] = result;

--- a/test/signal.html
+++ b/test/signal.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script type="module">
+      import { html, signal, render } from '../dist/dev/dom.js';
+
+      const items = signal([]);
+      const showList = signal(true);
+
+      const SPAN = ({ label }) =>
+        html`
+          <span>[${label}]</span>
+        `;
+
+      const LI = ({ text, label }) => html`
+        <li>
+          <${SPAN} label=${label} />
+          ${text}
+        </li>
+      `;
+
+      const UL = ({ items }) => html`
+        <ul>
+          ${items.value.map(
+            (item, index) =>
+              html`
+                <${LI} text=${item} label=${index} />
+              `
+          )}
+        </ul>
+      `;
+
+      const App = () => {
+        return html`
+          <div>
+            <h2>Nested Components Test</h2>
+            <button
+              @click=${() => {
+                showList.value = !showList.value;
+              }}
+            >
+              ${showList.value ? 'Hide' : 'Show'} List
+            </button>
+            ${showList.value
+              ? html`
+                  <${UL} items=${items} />
+                `
+              : html`
+                  <p>List is hidden</p>
+                `}
+          </div>
+        `;
+      };
+
+      document.body.append(
+        html`
+          <${App} />
+        `
+      );
+
+      const promisedTimeout = (timeout) => new Promise((resolve) => setTimeout(resolve, timeout));
+
+      // Add/hide items to trigger re-renders
+      for (let i = 0; i < 10; i++) {
+        await promisedTimeout(500);
+        showList.value = !showList.value;
+
+        await promisedTimeout(500);
+        items.value = [...items.value, `item ${i}`];
+      }
+    </script>
+  </head>
+</html>


### PR DESCRIPTION
Applied the same pattern for get/set direct from the `component` method to the `update` method where components are called during re-renders. This ensures components always return Holes consistently, whether during initial render or updates. Added test/signal.html to verify the re-renders work correctly. Fixes #157 